### PR TITLE
Fix Android camera required conflict with cordova-plugin-barcodescanner

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
             <uses-permission android:name="android.permission.CAMERA"/>
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-            <uses-feature android:name="android.hardware.camera" android:required="true"/>
+            <uses-feature android:name="android.hardware.camera" android:required="false"/>
             <uses-feature android:name="android.hardware.camera.autofocus"/>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">


### PR DESCRIPTION
When uses `cordova-plugin-flex-camera` and `cordova-plugin-barcodescanner` together and building with `cordova build` the following error occurs.

```
BUILD FAILED

Total time: 3.441 secs
Error: /Users/DQ/Development/git/DiegoDev/clones/colt/platforms/android/gradlew: Command failed with exit code 1 Error output:
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
/Users/DQ/Development/git/DiegoDev/clones/colt/platforms/android/AndroidManifest.xml:56:5-85 Error:
	Element uses-feature#android.hardware.camera at AndroidManifest.xml:56:5-85 duplicated with element declared at AndroidManifest.xml:54:5-84
/Users/DQ/Development/git/DiegoDev/clones/colt/platforms/android/AndroidManifest.xml Error:
	Validation failed, exiting

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':processDebugManifest'.
> Manifest merger failed with multiple errors, see logs

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
```

This is because `cordova-plugin-flex-camera` uses the Android camera feature like this:
```
 <uses-feature android:name="android.hardware.camera" android:required="true"/>
```
And `cordova-plugin-barcodescanner` uses the Android camera feature like this:
```
<uses-feature android:name="android.hardware.camera" android:required="false" />
```

I'm not sure what the correct fix for this is as some imply it's a problem with the Android build scripts.  For now I"m going to make the change in `cordova-plugin-flex-camera` to fix the build conflict with `cordova-plugin-barcodescanner` however this may not be the long term solution and may eventually need to be reverted.