### PR TITLE
green confirmation icon is no longer squished after taking a photo

### DIFF
--- a/src/android/happie_cam_layout.xml
+++ b/src/android/happie_cam_layout.xml
@@ -204,7 +204,7 @@
 
                                     <ImageButton
                                         android:layout_width="100dp"
-                                        android:layout_height="68dp"
+                                        android:layout_height="100dp"
                                         android:id="@+id/confirm"
                                         android:src="@drawable/camera_confirm_button"
                                         style="?android:attr/borderlessButtonStyle"
@@ -216,7 +216,8 @@
                                         android:padding="15dp"
                                         android:layout_marginRight="0dp"
                                         android:layout_marginLeft="-10dp"
-                                        android:layout_marginTop="90dp"/>
+                                        android:layout_marginTop="90dp"
+                                        android:layout_marginBottom="-15dp"/>
 
                                 </RelativeLayout>
 


### PR DESCRIPTION
Problem: Taking a photo to go with a citation would show a squished confirmation checkmark.

Reproduction: Open the app, login, connect to a printer, and select the "camera" icon. Take a photo and wait for it to be saved. A thumbnail will now be on the right, along with a green confirmation checkmark that has the Y axis squished.