### PR TITLE
Fix plugin to cordova-plugin-flex-camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ running this from the root folder pulls out the native source into the appropria
 run this from the ionic root to inject the plugins from the repository (recursive)
 
     gulp config
-    
+
 to inject the plugin use 
-    cordova plugin add https://github.com/jfspencer/jobnimbus-modern-camera.git
-    
+    cordova plugin add https://github.com/happieio/cordova-plugin-flex-camera.git
+
 hooks/addSwiftOptions.js needs to be copied into your projects hooks folder within after_plugin_add .
 
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "CustomCamera",
+  "name": "cordova-plugin-flex-camera",
   "version": "1.0.0",
   "description": "Custom Native Camera for iOS and Android",
   "cordova": {
-    "id": "com.jobnimbus.customcamera",
+    "id": "cordova-plugin-flex-camera",
     "platforms": [
       "android",
       "ios"
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jfspencer/jobnimbus-modern-camera.git"
+    "url": "https://github.com/happieio/cordova-plugin-flex-camera.git"
   },
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,14 +2,14 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:rim="http://www.blackberry.com/ns/widgets"
-        id="happie-plugin-cordova-camera"
+        id="cordova-plugin-flex-camera"
         version="1.0.0">
-    <name>CustomCamera</name>
+    <name>HappieCamera</name>
     <description>A custom Cordova camera focused on taking multiple high quality images in a single session</description>
     <license>MIT</license>
     <keywords>new, camera, multi, photo, modern, ecosystem:cordova</keywords>
-    <repo>https://github.com/jfspencer/happie-plugin-cordova-camera.git</repo>
-    <issue>https://github.com/jfspencer/happie-plugin-cordova-camera/issues</issue>
+    <repo>https://github.com/happieio/cordova-plugin-flex-camera.git</repo>
+    <issue>https://github.com/happieio/cordova-plugin-flex-camera/issues</issue>
 
     <js-module src="www/HappieCamera.js" name="HappieCamera">
         <clobbers target="HappieCamera"/>


### PR DESCRIPTION
Fix plugin inconsistencies to `cordova-plugin-flex-camera` which helps with adding and removing the Cordova plugin.