### PR TITLE
Fix quality param to compress image

### DIFF
--- a/src/android/HappieCamera.java
+++ b/src/android/HappieCamera.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.util.Log;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -23,9 +24,13 @@ public class HappieCamera extends CordovaPlugin {
 
     public static Integer quality;
 
+    private static final String TAG = "HappieCamera";
+
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
 
         this.quality = (Integer) args.getJSONObject(0).get("quality");
+        Log.d(TAG, "Quality: " + this.quality);
+
         this.callbackContext = callbackContext;
         currentAction = action;
 

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -253,9 +253,7 @@ public class HappieCameraActivity extends Activity {
                 params.setPictureSize(maxSize.width, maxSize.height);
             }
 
-            //hardwired to set picture size to 1280 x 960. this was changed by Anthony
-            params.setPictureSize(1280, 960);
-            params.setJpegQuality(50);
+            params.setJpegQuality(85);
             mCamera.setParameters(params);
         } catch (Exception e) {
             HappieCamera.callbackContext.error("Failed to initialize the camera");

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -300,7 +300,7 @@ public class HappieCameraActivity extends Activity {
 
             for(int i = 0; i < validPhotoDimensions.size(); i++) {
                 Camera.Size tmp = validPhotoDimensions.get(i);
-                Log.d(TAG, "Catch Exception Supported Picture Size i=" + i + ": " + tmp.width + "x" + tmp.height);
+                Log.d(TAG, "Exception: Supported Picture Size i=" + i + ": " + tmp.width + "x" + tmp.height);
             }
 
             if (validPhotoDimensions != null) {
@@ -313,15 +313,15 @@ public class HappieCameraActivity extends Activity {
                 Log.d(TAG, "max height: " + maxSize.height);
 
                 if (currentSize.height > maxSize.height || currentSize.width > maxSize.width) {
-                    Log.d(TAG, "catch exception: current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
+                    Log.d(TAG, "exception: current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
 
                     params.setPictureSize(maxSize.width, maxSize.height);
                 }
             }
 
             Camera.Size pictureSize = params.getPictureSize();
-            Log.d(TAG, "catch exception: set width: " + pictureSize.width);
-            Log.d(TAG, "catch exception: set height: " + pictureSize.height);
+            Log.d(TAG, "exception: set width: " + pictureSize.width);
+            Log.d(TAG, "exception: set height: " + pictureSize.height);
 
             params.setJpegQuality(85);
             mCamera.setParameters(params);

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -220,12 +220,15 @@ public class HappieCameraActivity extends Activity {
             Camera.Size jnLimit = null;
             switch (HappieCamera.quality) {
                 case 0: // High Compression
+                    Log.d(TAG, "Size: 1024x768");
                     jnLimit = mCamera.new Size(1024, 768);
                     break;
                 case 1: // Medium Compression
+                    Log.d(TAG, "Size: 2560x1440");
                     jnLimit = mCamera.new Size(2560, 1440);
                     break;
                 case 2: // Low Compression
+                    Log.d(TAG, "Size: 4096x2304");
                     jnLimit = mCamera.new Size(4096, 2304);
                     break;
             }
@@ -262,6 +265,9 @@ public class HappieCameraActivity extends Activity {
             Camera.Size currentSize = params.getPictureSize();
             Camera.Size maxSize = validPhotoDimensions.get(i);
             if (currentSize.height < maxSize.height || currentSize.width < maxSize.width) {
+                Log.d(TAG, "max width: " + maxSize.width);
+                Log.d(TAG, "max height: " + maxSize.height);
+
                 params.setPictureSize(maxSize.width, maxSize.height);
             }
 
@@ -276,6 +282,9 @@ public class HappieCameraActivity extends Activity {
                 Camera.Size maxSize = params.getSupportedPictureSizes().get(0);
                 if (currentSize.height < maxSize.height ||
                         currentSize.width < maxSize.width) {
+                    Log.d(TAG, "catch exception max width: " + maxSize.width);
+                    Log.d(TAG, "catch exception max height: " + maxSize.height);
+
                     params.setPictureSize(maxSize.width, maxSize.height);
                 }
             }

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -216,6 +216,12 @@ public class HappieCameraActivity extends Activity {
 
 
             List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
+
+            for(i = 0; i < validPhotoDimensions.size(); i++) {
+                Camera.Size tmp = validPhotoDimensions.get(i);
+                Log.d(TAG, "Supported Picture Size: " + tmp.width + "x" tmp.height);
+            }
+
             int i = 0;
             Camera.Size jnLimit = null;
             switch (HappieCamera.quality) {
@@ -262,32 +268,60 @@ public class HappieCameraActivity extends Activity {
                     }
                 }
             }
+
             Camera.Size currentSize = params.getPictureSize();
             Camera.Size maxSize = validPhotoDimensions.get(i);
+
+            Log.d(TAG, "current width: " + currentSize.width);
+            Log.d(TAG, "current height: " + currentSize.height);
+            Log.d(TAG, "max width: " + maxSize.width);
+            Log.d(TAG, "max height: " + maxSize.height);
+
             if (currentSize.height < maxSize.height || currentSize.width < maxSize.width) {
-                Log.d(TAG, "max width: " + maxSize.width);
-                Log.d(TAG, "max height: " + maxSize.height);
+                Log.d(TAG, "current size less than max size");
 
                 params.setPictureSize(maxSize.width, maxSize.height);
             }
 
+            Camera.Size pictureSize = params.getPictureSize();
+            Log.d(TAG, "set picture width: " + pictureSize.width);
+            Log.d(TAG, "set picture height: " + pictureSize.height);
+
             params.setJpegQuality(85);
             mCamera.setParameters(params);
         } catch (Exception e) {
+            Log.d(TAG, "initCameraSession exception: " + e.getMessage());
+
             //There is an intermittent failure while running setParameters, do not close the camera in that case
             //since the call back will fire pre-maturely and JN will not get notified.
+
+            List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
+            for(i = 0; i < validPhotoDimensions.size(); i++) {
+                Camera.Size tmp = validPhotoDimensions.get(i);
+                Log.d(TAG, "Catch Execption Supported Picture Size: " + tmp.width + "x" tmp.height);
+            }
+
             Camera.Parameters params = mCamera.getParameters();
-            if (params.getSupportedPictureSizes() != null) {
+            if (validPhotoDimensions != null) {
                 Camera.Size currentSize = params.getPictureSize();
-                Camera.Size maxSize = params.getSupportedPictureSizes().get(0);
-                if (currentSize.height < maxSize.height ||
-                        currentSize.width < maxSize.width) {
-                    Log.d(TAG, "catch exception max width: " + maxSize.width);
-                    Log.d(TAG, "catch exception max height: " + maxSize.height);
+                Camera.Size maxSize = validPhotoDimensions.get(0);
+
+                Log.d(TAG, "current width: " + currentSize.width);
+                Log.d(TAG, "current height: " + currentSize.height);
+                Log.d(TAG, "max width: " + maxSize.width);
+                Log.d(TAG, "max height: " + maxSize.height);
+
+                if (currentSize.height < maxSize.height || currentSize.width < maxSize.width) {
+                    Log.d(TAG, "catch exception current size less than max size");
 
                     params.setPictureSize(maxSize.width, maxSize.height);
                 }
             }
+
+            Camera.Size pictureSize = params.getPictureSize();
+            Log.d(TAG, "catch exception set width: " + pictureSize.width);
+            Log.d(TAG, "catch exception set height: " + pictureSize.height);
+
             params.setJpegQuality(85);
             mCamera.setParameters(params);
         }

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -219,7 +219,7 @@ public class HappieCameraActivity extends Activity {
 
             for(int i = 0; i < validPhotoDimensions.size(); i++) {
                 Camera.Size tmp = validPhotoDimensions.get(i);
-                Log.d(TAG, "Supported Picture Size: " + tmp.width + "x" + tmp.height);
+                Log.d(TAG, "Supported Picture Size i=" + i + ": " + tmp.width + "x" + tmp.height);
             }
 
             int i = 0;
@@ -277,8 +277,8 @@ public class HappieCameraActivity extends Activity {
             Log.d(TAG, "max width: " + maxSize.width);
             Log.d(TAG, "max height: " + maxSize.height);
 
-            if (currentSize.height < maxSize.height || currentSize.width < maxSize.width) {
-                Log.d(TAG, "current size less than max size");
+            if (currentSize.height > maxSize.height || currentSize.width > maxSize.width) {
+                Log.d(TAG, "current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
 
                 params.setPictureSize(maxSize.width, maxSize.height);
             }
@@ -300,7 +300,7 @@ public class HappieCameraActivity extends Activity {
 
             for(int i = 0; i < validPhotoDimensions.size(); i++) {
                 Camera.Size tmp = validPhotoDimensions.get(i);
-                Log.d(TAG, "Catch Execption Supported Picture Size: " + tmp.width + "x" + tmp.height);
+                Log.d(TAG, "Catch Exception Supported Picture Size i=" + i + ": " + tmp.width + "x" + tmp.height);
             }
 
             if (validPhotoDimensions != null) {

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -226,8 +226,8 @@ public class HappieCameraActivity extends Activity {
             Camera.Size jnLimit = null;
             switch (HappieCamera.quality) {
                 case 0: // High Compression
-                    Log.d(TAG, "Size: 1024x768");
-                    jnLimit = mCamera.new Size(1024, 768);
+                    Log.d(TAG, "Size: 1280x720");
+                    jnLimit = mCamera.new Size(1280, 720);
                     break;
                 case 1: // Medium Compression
                     Log.d(TAG, "Size: 2560x1440");

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -226,15 +226,15 @@ public class HappieCameraActivity extends Activity {
             Camera.Size jnLimit = null;
             switch (HappieCamera.quality) {
                 case 0: // High Compression
-                    Log.d(TAG, "Size: 1280x720");
+                    Log.d(TAG, "High Compression: 1280x720");
                     jnLimit = mCamera.new Size(1280, 720);
                     break;
                 case 1: // Medium Compression
-                    Log.d(TAG, "Size: 2560x1440");
+                    Log.d(TAG, "Medium Compression: 2560x1440");
                     jnLimit = mCamera.new Size(2560, 1440);
                     break;
                 case 2: // Low Compression
-                    Log.d(TAG, "Size: 4096x2304");
+                    Log.d(TAG, "Low Compression: 4096x2304");
                     jnLimit = mCamera.new Size(4096, 2304);
                     break;
             }
@@ -272,10 +272,8 @@ public class HappieCameraActivity extends Activity {
             Camera.Size currentSize = params.getPictureSize();
             Camera.Size maxSize = validPhotoDimensions.get(i);
 
-            Log.d(TAG, "current width: " + currentSize.width);
-            Log.d(TAG, "current height: " + currentSize.height);
-            Log.d(TAG, "max width: " + maxSize.width);
-            Log.d(TAG, "max height: " + maxSize.height);
+            Log.d(TAG, "current size: " + currentSize.width + "x" + currentSize.height);
+            Log.d(TAG, "max size: " + maxSize.width + "x" + maxSize.height);
 
             if (currentSize.height > maxSize.height || currentSize.width > maxSize.width) {
                 Log.d(TAG, "current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
@@ -284,8 +282,7 @@ public class HappieCameraActivity extends Activity {
             }
 
             Camera.Size pictureSize = params.getPictureSize();
-            Log.d(TAG, "set picture width: " + pictureSize.width);
-            Log.d(TAG, "set picture height: " + pictureSize.height);
+            Log.d(TAG, "picture size: " + pictureSize.width + "x" + pictureSize.height);
 
             params.setJpegQuality(85);
             mCamera.setParameters(params);
@@ -303,14 +300,59 @@ public class HappieCameraActivity extends Activity {
                 Log.d(TAG, "Exception: Supported Picture Size i=" + i + ": " + tmp.width + "x" + tmp.height);
             }
 
+            int i = 0;
+            Camera.Size jnLimit = null;
+            switch (HappieCamera.quality) {
+                case 0: // High Compression
+                    Log.d(TAG, "Exception: High Compression: 1280x720");
+                    jnLimit = mCamera.new Size(1280, 720);
+                    break;
+                case 1: // Medium Compression
+                    Log.d(TAG, "Exception: Medium Compression: 2560x1440");
+                    jnLimit = mCamera.new Size(2560, 1440);
+                    break;
+                case 2: // Low Compression
+                    Log.d(TAG, "Exception: Low Compression: 4096x2304");
+                    jnLimit = mCamera.new Size(4096, 2304);
+                    break;
+            }
+
+            int lastLongSide = 0, lastShortSide = 0;
+            if (jnLimit != null && validPhotoDimensions.size() != 1) {
+                i = validPhotoDimensions.size();
+                while (--i > 0) {
+                    Camera.Size tmp = validPhotoDimensions.get(i);
+                    int longSide, shortSide;
+                    if (tmp.width > tmp.height) {
+                        longSide = tmp.width;
+                        shortSide = tmp.height;
+                    } else {
+                        longSide = tmp.height;
+                        shortSide = tmp.width;
+                    }
+                    if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
+                        if (lastLongSide <= longSide || lastShortSide <= shortSide) {
+                            lastLongSide = longSide;
+                            lastShortSide = shortSide;
+                        } else {
+                            i++;
+                            break;
+                        }
+                    } else {
+                        if(lastLongSide!=0 && lastShortSide!=0) {
+                            i++;
+                            break;
+                        }
+                    }
+                }
+            }
+
             if (validPhotoDimensions != null) {
                 Camera.Size currentSize = params.getPictureSize();
-                Camera.Size maxSize = validPhotoDimensions.get(0);
+                Camera.Size maxSize = validPhotoDimensions.get(i);
 
-                Log.d(TAG, "current width: " + currentSize.width);
-                Log.d(TAG, "current height: " + currentSize.height);
-                Log.d(TAG, "max width: " + maxSize.width);
-                Log.d(TAG, "max height: " + maxSize.height);
+                Log.d(TAG, "exception: current size: " + currentSize.width + "x" + currentSize.height);
+                Log.d(TAG, "exception: max size: " + maxSize.width + "x" + maxSize.height);
 
                 if (currentSize.height > maxSize.height || currentSize.width > maxSize.width) {
                     Log.d(TAG, "exception: current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
@@ -320,8 +362,7 @@ public class HappieCameraActivity extends Activity {
             }
 
             Camera.Size pictureSize = params.getPictureSize();
-            Log.d(TAG, "exception: set width: " + pictureSize.width);
-            Log.d(TAG, "exception: set height: " + pictureSize.height);
+            Log.d(TAG, "exception: picture size: " + pictureSize.width + "x" + pictureSize.height);
 
             params.setJpegQuality(85);
             mCamera.setParameters(params);

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -271,7 +271,10 @@ public class HappieCameraActivity extends Activity {
                 params.setPictureSize(maxSize.width, maxSize.height);
             }
 
-            params.setJpegQuality(85);
+            //hardwired to set picture size to 1280 x 960. this was changed by Anthony
+            params.setPictureSize(1280, 960);
+            params.setJpegQuality(50);
+
             mCamera.setParameters(params);
         } catch (Exception e) {
             //There is an intermittent failure while running setParameters, do not close the camera in that case
@@ -288,7 +291,11 @@ public class HappieCameraActivity extends Activity {
                     params.setPictureSize(maxSize.width, maxSize.height);
                 }
             }
-            params.setJpegQuality(85);
+
+            //hardwired to set picture size to 1280 x 960. this was changed by Anthony
+            params.setPictureSize(1280, 960);
+            params.setJpegQuality(50);
+
             mCamera.setParameters(params);
         }
     }

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -271,10 +271,7 @@ public class HappieCameraActivity extends Activity {
                 params.setPictureSize(maxSize.width, maxSize.height);
             }
 
-            //hardwired to set picture size to 1280 x 960. this was changed by Anthony
-            params.setPictureSize(1280, 960);
-            params.setJpegQuality(50);
-
+            params.setJpegQuality(85);
             mCamera.setParameters(params);
         } catch (Exception e) {
             //There is an intermittent failure while running setParameters, do not close the camera in that case
@@ -291,11 +288,7 @@ public class HappieCameraActivity extends Activity {
                     params.setPictureSize(maxSize.width, maxSize.height);
                 }
             }
-
-            //hardwired to set picture size to 1280 x 960. this was changed by Anthony
-            params.setPictureSize(1280, 960);
-            params.setJpegQuality(50);
-
+            params.setJpegQuality(85);
             mCamera.setParameters(params);
         }
     }

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -312,16 +312,16 @@ public class HappieCameraActivity extends Activity {
                 Log.d(TAG, "max width: " + maxSize.width);
                 Log.d(TAG, "max height: " + maxSize.height);
 
-                if (currentSize.height < maxSize.height || currentSize.width < maxSize.width) {
-                    Log.d(TAG, "catch exception current size less than max size");
+                if (currentSize.height > maxSize.height || currentSize.width > maxSize.width) {
+                    Log.d(TAG, "catch exception: current size greater than max size, resize to max size " + maxSize.width + "x" + maxSize.height);
 
                     params.setPictureSize(maxSize.width, maxSize.height);
                 }
             }
 
             Camera.Size pictureSize = params.getPictureSize();
-            Log.d(TAG, "catch exception set width: " + pictureSize.width);
-            Log.d(TAG, "catch exception set height: " + pictureSize.height);
+            Log.d(TAG, "catch exception: set width: " + pictureSize.width);
+            Log.d(TAG, "catch exception: set height: " + pictureSize.height);
 
             params.setJpegQuality(85);
             mCamera.setParameters(params);

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -284,7 +284,7 @@ public class HappieCameraActivity extends Activity {
             Camera.Size pictureSize = params.getPictureSize();
             Log.d(TAG, "picture size: " + pictureSize.width + "x" + pictureSize.height);
 
-            params.setJpegQuality(85);
+            params.setJpegQuality(50);
             mCamera.setParameters(params);
         } catch (Exception e) {
             Log.d(TAG, "initCameraSession exception: " + e.getMessage());
@@ -364,7 +364,7 @@ public class HappieCameraActivity extends Activity {
             Camera.Size pictureSize = params.getPictureSize();
             Log.d(TAG, "exception: picture size: " + pictureSize.width + "x" + pictureSize.height);
 
-            params.setJpegQuality(85);
+            params.setJpegQuality(50);
             mCamera.setParameters(params);
         }
     }

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -256,7 +256,8 @@ public class HappieCameraActivity extends Activity {
             params.setJpegQuality(85);
             mCamera.setParameters(params);
         } catch (Exception e) {
-            HappieCamera.callbackContext.error("Failed to initialize the camera");
+            String errMsg = e.getMessage();
+            HappieCamera.callbackContext.error(errMsg);
             PluginResult r = new PluginResult(PluginResult.Status.ERROR);
             HappieCamera.callbackContext.sendPluginResult(r);
         }

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -217,7 +217,7 @@ public class HappieCameraActivity extends Activity {
 
             List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
 
-            for(i = 0; i < validPhotoDimensions.size(); i++) {
+            for(int i = 0; i < validPhotoDimensions.size(); i++) {
                 Camera.Size tmp = validPhotoDimensions.get(i);
                 Log.d(TAG, "Supported Picture Size: " + tmp.width + "x" + tmp.height);
             }
@@ -295,13 +295,14 @@ public class HappieCameraActivity extends Activity {
             //There is an intermittent failure while running setParameters, do not close the camera in that case
             //since the call back will fire pre-maturely and JN will not get notified.
 
+            Camera.Parameters params = mCamera.getParameters();
             List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
-            for(i = 0; i < validPhotoDimensions.size(); i++) {
+
+            for(int i = 0; i < validPhotoDimensions.size(); i++) {
                 Camera.Size tmp = validPhotoDimensions.get(i);
                 Log.d(TAG, "Catch Execption Supported Picture Size: " + tmp.width + "x" + tmp.height);
             }
 
-            Camera.Parameters params = mCamera.getParameters();
             if (validPhotoDimensions != null) {
                 Camera.Size currentSize = params.getPictureSize();
                 Camera.Size maxSize = validPhotoDimensions.get(0);

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -226,8 +226,8 @@ public class HappieCameraActivity extends Activity {
             Camera.Size jnLimit = null;
             switch (HappieCamera.quality) {
                 case 0: // High Compression
-                    Log.d(TAG, "High Compression: 1280x720");
-                    jnLimit = mCamera.new Size(1280, 720);
+                    Log.d(TAG, "High Compression: 1280x960");
+                    jnLimit = mCamera.new Size(1280, 960);
                     break;
                 case 1: // Medium Compression
                     Log.d(TAG, "Medium Compression: 2560x1440");
@@ -304,8 +304,8 @@ public class HappieCameraActivity extends Activity {
             Camera.Size jnLimit = null;
             switch (HappieCamera.quality) {
                 case 0: // High Compression
-                    Log.d(TAG, "Exception: High Compression: 1280x720");
-                    jnLimit = mCamera.new Size(1280, 720);
+                    Log.d(TAG, "Exception: High Compression: 1280x960");
+                    jnLimit = mCamera.new Size(1280, 960);
                     break;
                 case 1: // Medium Compression
                     Log.d(TAG, "Exception: Medium Compression: 2560x1440");

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -219,7 +219,7 @@ public class HappieCameraActivity extends Activity {
 
             for(i = 0; i < validPhotoDimensions.size(); i++) {
                 Camera.Size tmp = validPhotoDimensions.get(i);
-                Log.d(TAG, "Supported Picture Size: " + tmp.width + "x" tmp.height);
+                Log.d(TAG, "Supported Picture Size: " + tmp.width + "x" + tmp.height);
             }
 
             int i = 0;
@@ -298,7 +298,7 @@ public class HappieCameraActivity extends Activity {
             List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
             for(i = 0; i < validPhotoDimensions.size(); i++) {
                 Camera.Size tmp = validPhotoDimensions.get(i);
-                Log.d(TAG, "Catch Execption Supported Picture Size: " + tmp.width + "x" tmp.height);
+                Log.d(TAG, "Catch Execption Supported Picture Size: " + tmp.width + "x" + tmp.height);
             }
 
             Camera.Parameters params = mCamera.getParameters();


### PR DESCRIPTION
This PR fixes the quality parameter to actually compress the image instead of doing nothing.  This should also fix working with multiple devices and supported image dimensions.

**!!! SQUASH ME !!!**

- Changes the high compression to 1280x960
- Merge original code for initCameraSession
- Adds Java debug logging
- Handle intermittent setParameters failure
- Work with multiple devices and supported image dimensions