### PR TITLE
Remove square dimensions from photo dimensions

### DIFF
--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -32,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -215,7 +216,7 @@ public class HappieCameraActivity extends Activity {
             }
 
             List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
-            List<Camera.Size> validPhotoDimensions = new List<Camera.Size>();
+            List<Camera.Size> validPhotoDimensions = new ArrayList<Camera.Size>();
 
             for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
                 Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);
@@ -301,7 +302,7 @@ public class HappieCameraActivity extends Activity {
 
             Camera.Parameters params = mCamera.getParameters();
             List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
-            List<Camera.Size> validPhotoDimensions = new List<Camera.Size>();
+            List<Camera.Size> validPhotoDimensions = new ArrayList<Camera.Size>();
 
             for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
                 Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -215,7 +215,7 @@ public class HappieCameraActivity extends Activity {
             }
 
             List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
-            List<Camera.Size> validPhotoDimensions = new ArrayList<Camera.Size>();
+            List<Camera.Size> validPhotoDimensions = new List<Camera.Size>();
 
             for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
                 Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);
@@ -301,7 +301,7 @@ public class HappieCameraActivity extends Activity {
 
             Camera.Parameters params = mCamera.getParameters();
             List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
-            List<Camera.Size> validPhotoDimensions = new ArrayList<Camera.Size>();
+            List<Camera.Size> validPhotoDimensions = new List<Camera.Size>();
 
             for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
                 Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -214,12 +214,17 @@ public class HappieCameraActivity extends Activity {
                     flash.setImageResource(R.drawable.camera_flash_on);
             }
 
+            List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
+            List<Camera.Size> validPhotoDimensions;
 
-            List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
+            for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
+                Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);
 
-            for(int i = 0; i < validPhotoDimensions.size(); i++) {
-                Camera.Size validDimensions = validPhotoDimensions.get(i);
-                Log.d(TAG, "Supported Picture Size i=" + i + ": " + validDimensions.width + "x" + validDimensions.height);
+                // Remove square dimensions
+                if (supportedDimensions.width != supportedDimensions.height) {
+                    Log.d(TAG, "Supported Picture Size i=" + i + ": " + supportedDimensions.width + "x" + supportedDimensions.height);
+                    validPhotoDimensions.add(supportedDimensions);
+                }
             }
 
             int i = 0;
@@ -245,9 +250,6 @@ public class HappieCameraActivity extends Activity {
                 while (--i > 0) {
                     Camera.Size validDimensions = validPhotoDimensions.get(i);
                     int longSide, shortSide;
-
-                    // Skip square dimensions as they trigger selecting smaller image dimensions
-                    if (validDimensions.width == validDimensions.height) continue;
 
                     if (validDimensions.width > validDimensions.height) {
                         longSide = validDimensions.width;
@@ -298,11 +300,17 @@ public class HappieCameraActivity extends Activity {
             //since the call back will fire pre-maturely and JN will not get notified.
 
             Camera.Parameters params = mCamera.getParameters();
-            List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
+            List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
+            List<Camera.Size> validPhotoDimensions;
 
-            for(int i = 0; i < validPhotoDimensions.size(); i++) {
-                Camera.Size validDimensions = validPhotoDimensions.get(i);
-                Log.d(TAG, "Exception: Supported Picture Size i=" + i + ": " + validDimensions.width + "x" + validDimensions.height);
+            for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
+                Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);
+
+                // Remove square dimensions
+                if (supportedDimensions.width != supportedDimensions.height) {
+                    Log.d(TAG, "Supported Picture Size i=" + i + ": " + supportedDimensions.width + "x" + supportedDimensions.height);
+                    validPhotoDimensions.add(supportedDimensions);
+                }
             }
 
             int i = 0;
@@ -328,9 +336,6 @@ public class HappieCameraActivity extends Activity {
                 while (--i > 0) {
                     Camera.Size validDimensions = validPhotoDimensions.get(i);
                     int longSide, shortSide;
-
-                    // Skip square dimensions as they trigger selecting smaller image dimensions
-                    if (validDimensions.width == validDimensions.height) continue;
 
                     if (validDimensions.width > validDimensions.height) {
                         longSide = validDimensions.width;

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -253,7 +253,7 @@ public class HappieCameraActivity extends Activity {
                         shortSide = tmp.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
-                        if (lastLongSide <= longSide || lastShortSide <= shortSide) {
+                        if (lastLongSide <= longSide && lastShortSide <= shortSide) {
                             lastLongSide = longSide;
                             lastShortSide = shortSide;
                         } else {
@@ -331,7 +331,7 @@ public class HappieCameraActivity extends Activity {
                         shortSide = tmp.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
-                        if (lastLongSide <= longSide || lastShortSide <= shortSide) {
+                        if (lastLongSide <= longSide && lastShortSide <= shortSide) {
                             lastLongSide = longSide;
                             lastShortSide = shortSide;
                         } else {

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -253,7 +253,7 @@ public class HappieCameraActivity extends Activity {
                         shortSide = tmp.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
-                        if (lastLongSide <= longSide && lastShortSide <= shortSide) {
+                        if (lastLongSide <= longSide || lastShortSide <= shortSide) {
                             lastLongSide = longSide;
                             lastShortSide = shortSide;
                         } else {
@@ -331,7 +331,7 @@ public class HappieCameraActivity extends Activity {
                         shortSide = tmp.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
-                        if (lastLongSide <= longSide && lastShortSide <= shortSide) {
+                        if (lastLongSide <= longSide || lastShortSide <= shortSide) {
                             lastLongSide = longSide;
                             lastShortSide = shortSide;
                         } else {

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -215,7 +215,7 @@ public class HappieCameraActivity extends Activity {
             }
 
             List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
-            List<Camera.Size> validPhotoDimensions;
+            List<Camera.Size> validPhotoDimensions = new ArrayList<Camera.Size>();
 
             for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
                 Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);
@@ -301,7 +301,7 @@ public class HappieCameraActivity extends Activity {
 
             Camera.Parameters params = mCamera.getParameters();
             List<Camera.Size> supportedPhotoDimensions = params.getSupportedPictureSizes();
-            List<Camera.Size> validPhotoDimensions;
+            List<Camera.Size> validPhotoDimensions = new ArrayList<Camera.Size>();
 
             for(int i = 0; i < supportedPhotoDimensions.size(); i++) {
                 Camera.Size supportedDimensions = supportedPhotoDimensions.get(i);

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -331,7 +331,7 @@ public class HappieCameraActivity extends Activity {
                         shortSide = tmp.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
-                        if (lastLongSide <= longSide || lastShortSide <= shortSide) {
+                        if (lastLongSide <= longSide && lastShortSide <= shortSide) {
                             lastLongSide = longSide;
                             lastShortSide = shortSide;
                         } else {

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -245,6 +245,10 @@ public class HappieCameraActivity extends Activity {
                 while (--i > 0) {
                     Camera.Size validDimensions = validPhotoDimensions.get(i);
                     int longSide, shortSide;
+
+                    // Skip square dimensions as they trigger selecting smaller image dimensions
+                    if (validDimensions.width == validDimensions.height) continue;
+
                     if (validDimensions.width > validDimensions.height) {
                         longSide = validDimensions.width;
                         shortSide = validDimensions.height;
@@ -252,6 +256,7 @@ public class HappieCameraActivity extends Activity {
                         longSide = validDimensions.height;
                         shortSide = validDimensions.width;
                     }
+
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
                         if (lastLongSide <= longSide || lastShortSide <= shortSide) {
                             lastLongSide = longSide;
@@ -323,6 +328,10 @@ public class HappieCameraActivity extends Activity {
                 while (--i > 0) {
                     Camera.Size validDimensions = validPhotoDimensions.get(i);
                     int longSide, shortSide;
+
+                    // Skip square dimensions as they trigger selecting smaller image dimensions
+                    if (validDimensions.width == validDimensions.height) continue;
+
                     if (validDimensions.width > validDimensions.height) {
                         longSide = validDimensions.width;
                         shortSide = validDimensions.height;
@@ -330,6 +339,7 @@ public class HappieCameraActivity extends Activity {
                         longSide = validDimensions.height;
                         shortSide = validDimensions.width;
                     }
+
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
                         if (lastLongSide <= longSide || lastShortSide <= shortSide) {
                             lastLongSide = longSide;

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -218,8 +218,8 @@ public class HappieCameraActivity extends Activity {
             List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
 
             for(int i = 0; i < validPhotoDimensions.size(); i++) {
-                Camera.Size tmp = validPhotoDimensions.get(i);
-                Log.d(TAG, "Supported Picture Size i=" + i + ": " + tmp.width + "x" + tmp.height);
+                Camera.Size validDimensions = validPhotoDimensions.get(i);
+                Log.d(TAG, "Supported Picture Size i=" + i + ": " + validDimensions.width + "x" + validDimensions.height);
             }
 
             int i = 0;
@@ -243,14 +243,14 @@ public class HappieCameraActivity extends Activity {
             if (jnLimit != null && validPhotoDimensions.size() != 1) {
                 i = validPhotoDimensions.size();
                 while (--i > 0) {
-                    Camera.Size tmp = validPhotoDimensions.get(i);
+                    Camera.Size validDimensions = validPhotoDimensions.get(i);
                     int longSide, shortSide;
-                    if (tmp.width > tmp.height) {
-                        longSide = tmp.width;
-                        shortSide = tmp.height;
+                    if (validDimensions.width > validDimensions.height) {
+                        longSide = validDimensions.width;
+                        shortSide = validDimensions.height;
                     } else {
-                        longSide = tmp.height;
-                        shortSide = tmp.width;
+                        longSide = validDimensions.height;
+                        shortSide = validDimensions.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
                         if (lastLongSide <= longSide || lastShortSide <= shortSide) {
@@ -296,8 +296,8 @@ public class HappieCameraActivity extends Activity {
             List<Camera.Size> validPhotoDimensions = params.getSupportedPictureSizes();
 
             for(int i = 0; i < validPhotoDimensions.size(); i++) {
-                Camera.Size tmp = validPhotoDimensions.get(i);
-                Log.d(TAG, "Exception: Supported Picture Size i=" + i + ": " + tmp.width + "x" + tmp.height);
+                Camera.Size validDimensions = validPhotoDimensions.get(i);
+                Log.d(TAG, "Exception: Supported Picture Size i=" + i + ": " + validDimensions.width + "x" + validDimensions.height);
             }
 
             int i = 0;
@@ -321,14 +321,14 @@ public class HappieCameraActivity extends Activity {
             if (jnLimit != null && validPhotoDimensions.size() != 1) {
                 i = validPhotoDimensions.size();
                 while (--i > 0) {
-                    Camera.Size tmp = validPhotoDimensions.get(i);
+                    Camera.Size validDimensions = validPhotoDimensions.get(i);
                     int longSide, shortSide;
-                    if (tmp.width > tmp.height) {
-                        longSide = tmp.width;
-                        shortSide = tmp.height;
+                    if (validDimensions.width > validDimensions.height) {
+                        longSide = validDimensions.width;
+                        shortSide = validDimensions.height;
                     } else {
-                        longSide = tmp.height;
-                        shortSide = tmp.width;
+                        longSide = validDimensions.height;
+                        shortSide = validDimensions.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
                         if (lastLongSide <= longSide || lastShortSide <= shortSide) {

--- a/src/android/HappieCameraActivity.java
+++ b/src/android/HappieCameraActivity.java
@@ -331,7 +331,7 @@ public class HappieCameraActivity extends Activity {
                         shortSide = tmp.width;
                     }
                     if (jnLimit.width >= longSide && jnLimit.height >= shortSide) {
-                        if (lastLongSide <= longSide && lastShortSide <= shortSide) {
+                        if (lastLongSide <= longSide || lastShortSide <= shortSide) {
                             lastLongSide = longSide;
                             lastShortSide = shortSide;
                         } else {


### PR DESCRIPTION
**!!! SQUASH ME !!!**

Add-on PR to https://github.com/iParqDevelopers/cordova-plugin-flex-camera/pull/5 to remove square dimensions as they cause issues selecting lower resolutions depending on the way supported resolutions are listed by the device.

If the high compression quality setting is set to `1280x960` then the following dimensions will yield different results based on the supported resolution order.  The fix for this was to remove the square dimensions as they are not desired for this feature otherwise lower than desired resolutions would be selected depending on the device.

Here are some examples of devices and the order of the supported resolution order which yields different results.

**Samsung Galaxy S20**
```
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=0: 4032x3024
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=1: 4032x2268
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=2: 4032x1816
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=3: 3024x3024
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=4: 2400x1080
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=5: 1920x864
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=6: 1920x824
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=7: 3840x2160
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=8: 1920x1080
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=9: 1440x1080
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=10: 1088x1088
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=11: 1280x720 (would get selected)
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=12: 960x720
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=13: 720x480
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=14: 640x480
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=15: 640x360
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=16: 352x288
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=17: 320x240
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=18: 256x144
2021-03-23 17:39:11.737 D/HappieCameraActivity: Supported Picture Size i=19: 176x144
```

**Samsung Galaxy S10**
```
2021-03-25 14:15:56.301 D/HappieCameraActivity: Supported Picture Size i=0: 4032x3024
2021-03-25 14:15:56.301 D/HappieCameraActivity: Supported Picture Size i=1: 4032x2268
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=2: 4032x1908
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=3: 3024x3024
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=4: 3840x2160
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=5: 1920x1080
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=6: 1280x720
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=7: 2288x1080
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=8: 1920x910
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=9: 960x540
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=10: 1440x1080
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=11: 1280x960 (would get selected with fix)
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=12: 1088x1088
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=13: 960x720 (would get selected previously)
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=14: 720x480
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=15: 640x480
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=16: 640x360
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=17: 352x288
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=18: 320x240
2021-03-25 14:15:56.302 D/HappieCameraActivity: Supported Picture Size i=19: 176x144
```